### PR TITLE
fix(expectOutput): replace origin console.log call

### DIFF
--- a/src/tests.js
+++ b/src/tests.js
@@ -20,10 +20,10 @@ const expectOutput = async (expected, run = (f) => f()) => {
     }
     const content = logs.join('\n').toString().trim();
     expect(content).toBe(expected.toString());
-    console.log();
-    console.log(chalk.green('Tests have passed!'));
+    oldLog();
+    oldLog(chalk.green('Tests have passed!'));
   } catch (e) {
-    console.log(cleanStack(e.stack));
+    oldLog(cleanStack(e.stack));
     process.exit(1);
   }
 };


### PR DESCRIPTION
Пользователь может подменить функцию console.log(). Это приводит к ошибке, но тесты проходят успешно - https://ru.code-basics.com/languages/javascript/modules/data-types/lessons/weak-typing#comment-4929244113