### PR TITLE
Устаревание String.prototype.substr

### DIFF
--- a/modules/48-conditionals/60-ternary-operator/description.ru.yml
+++ b/modules/48-conditionals/60-ternary-operator/description.ru.yml
@@ -46,7 +46,7 @@ theory: |
 
   ```javascript
   const getTypeOfSentence = (sentence) => {
-    const lastChar = sentence.substr(-1);
+    const lastChar = sentence.slice(-1);
 
     if (lastChar === '?') {
         return 'question';
@@ -60,7 +60,7 @@ theory: |
 
   ```javascript
   const getTypeOfSentence = (sentence) => {
-    const lastChar = sentence.substr(-1);
+    const lastChar = sentence.slice(-1);
 
     return (lastChar === '?') ? 'question' : 'normal';
   };


### PR DESCRIPTION
В примере используется устаревающий метод String.substr, который может быть убран в ближайшем будущем.
Возможно будущим программистам стоит сразу опираться на заменяющие устаревшему методы - действующие и актуальные, такие как String.substring и String.slice.

Ссылки:
https://developer.mozilla.org/uk/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string_methods
https://262.ecma-international.org/9.0/#sec-string.prototype.substr
https://262.ecma-international.org/9.0/#sec-additional-ecmascript-features-for-web-browsers