### PR TITLE
update test.js for covering more cases

### DIFF
--- a/modules/50-loops/20-aggregation-numbers/test.js
+++ b/modules/50-loops/20-aggregation-numbers/test.js
@@ -4,4 +4,8 @@ test((f) => {
   expect(f(2, 2)).toEqual(2);
   expect(f(1, 3)).toEqual(6);
   expect(f(1, 5)).toEqual(120);
+  expect(f(2, 5)).toEqual(120);
+  expect(f(0, 5)).toEqual(0);
+  expect(f(-4, -2)).toEqual(-24);
+  expect(f(-4, -3)).toEqual(12);
 });


### PR DESCRIPTION
Updating test.js covering. The current set of tests is not full.
Just because tests f(1, 3) and f(1, 5) start from 1 (the neutral element for multiplying), they can't prevent newbies to start their loops from the second element of the slice. 
E.g. f(1, 5) == f(2, 5). 
But (2,5) != (3,5) -- and cases as this was not covered.
Here is an example of a wrong function that passes through all tests.
```javascript
const multiplyNumbersFromRange = (a, b) => {
  let i = a + 1;  // here we can start from second element and it will be okay
  let mult = 1;
  if (b-a != 0) {
    while (i <= b) {
      mult = mult * i;
      i = i + 1;
    } 
  }else {
      mult = a;
	}
  return mult;
}
```
Also, add some tests with negative numbers for covering sign issues with odd and even sequences.