### PR TITLE
Fix 25

### DIFF
--- a/modules/35-calling-functions/270-deterministic/test.js
+++ b/modules/35-calling-functions/270-deterministic/test.js
@@ -1,9 +1,10 @@
 // @ts-check
-
 import { expectOutput, expect } from 'hexlet-basics/tests';
 
 expectOutput((content) => {
+  expect(content).not.toEqual('');
   const value = Number(content);
+  expect(Number.isInteger(value)).toEqual(true);
   expect(value).toBeGreaterThanOrEqual(0);
   expect(value).toBeLessThanOrEqual(10);
 });

--- a/modules/35-calling-functions/270-deterministic/test.js
+++ b/modules/35-calling-functions/270-deterministic/test.js
@@ -1,4 +1,5 @@
 // @ts-check
+
 import { expectOutput, expect } from 'hexlet-basics/tests';
 
 expectOutput((content) => {

--- a/modules/40-define-functions/150-define-functions-return/test.js
+++ b/modules/40-define-functions/150-define-functions-return/test.js
@@ -4,6 +4,6 @@ import { test, expect } from '@jest/globals';
 import f from './index.js';
 
 test('test', () => {
-  expect(f()).toBeGreaterThan(0);
-  expect(f()).toBeLessThan(10);
+  expect(f()).toBeGreaterThanOrEqual(0);
+  expect(f()).toBeLessThanOrEqual(10);
 });


### PR DESCRIPTION
Проходила проверка без решения. Пустая строка в выводе приводилась к нулю и ноль как валидное значение проходил тесты. Добавил проверку, что полученное число -целое