### PR TITLE
Correct logs processing in expectOutput

### DIFF
--- a/src/tests.js
+++ b/src/tests.js
@@ -20,14 +20,14 @@ const expectOutput = async (expected, run = (f) => f()) => {
   const oldLog = console.log;
   global.console.log = (/** @type {any} */ ...args) => {
     oldLog(...args);
-    logs.push(...args);
+    logs.push(args);
   };
   try {
     const { default: f } = await import(getPathToIndex());
     if (typeof f === 'function') {
       run(f);
     }
-    const content = logs.map(String).join('\n').trim();
+    const content = logs.map(oneCallData => oneCallData.map(String).join(' ')).join('\n').trim();
     if (typeof expected === 'function') {
       expected(content);
     } else {


### PR DESCRIPTION
Instead of joining calls of `console.log` with `\n` we joined each argument which gave us incorrect string to compare to. Now, it first joins arguments with space character and only then joins them together with '\n' like in the real output.