### PR TITLE
fix: сorrect the name of the default

### DIFF
--- a/modules/48-conditionals/40-if-else/index.js
+++ b/modules/48-conditionals/40-if-else/index.js
@@ -12,4 +12,4 @@ const normalizeUrl = (site) => {
 };
 // END
 
-export default normalizeUrl;
+export default normalizerUrl;


### PR DESCRIPTION
Because of the wrong name, even the correct code gives an error.

string: 15. 
p.s. User can fix it himself through a quick fix. But, this is a training site and the error is not particularly obvious.