### PR TITLE
fix(ci): починить code-lint (tsc + biome)

### DIFF
--- a/src/hexlet/string.js
+++ b/src/hexlet/string.js
@@ -23,4 +23,4 @@ function length(s) {
   return s.length;
 }
 
-export { toUpperCase, toLowerCase, reverse, length };
+export { length, reverse, toLowerCase, toUpperCase };

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Что

Чинит падающий CI (`make code-lint` внутри `ci-check`).

1. **`vitest.config.js`** — `defineConfig` теперь импортируется из `vitest/config`, а не из `vite`. У vite-овского `UserConfigExport` нет свойства `test`, поэтому `npx tsc --build` падал:

   ```
   vitest.config.js(4,3): error TS2769: No overload matches this call.
     Object literal may only specify known properties, and 'test' does not exist in type 'UserConfigExport'.
   ```

   `vite` даже не значится прямой зависимостью в `package.json` — `vitest/config` тут канонически правильный источник.

2. **`src/hexlet/string.js`** — отсортированы экспорты (biome `assist/source/organizeImports`). Эта ошибка была скрыта за падением tsc и всплыла, как только tsc починили (tsc выполняется до biome).

## Почему

Без обоих правок `code-lint` не проходит, и CI красный на любом PR/пуше в `main`.

## Проверка

Полный прогон как в CI — зелёный:

\`\`\`
make ci-check   # exited with code 0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)