### PR TITLE
fix(50-loops): use full assignment form before syntax-sugar lesson, align with Python (T04)

### DIFF
--- a/modules/50-loops/10-while/ru/README.md
+++ b/modules/50-loops/10-while/ru/README.md
@@ -12,7 +12,7 @@
 let counter = 0;
 while (counter < 5) {
   console.log('Hello!');
-  counter += 1;
+  counter = counter + 1;
 }
 
 // => Hello!
@@ -42,7 +42,7 @@ counter = 0
 │     true │
 │          ↓
 │    console.log('Hello!')
-│    counter += 1
+│    counter = counter + 1
 └──────────┘
       false → выход из цикла
 ```
@@ -55,13 +55,13 @@ counter = 0
 let counter = 0;
 while (counter < 2) {
   console.log('Hello!');
-  counter += 1;
+  counter = counter + 1;
 }
 
 console.log('End of loop');
 ```
 
-Здесь `console.log('Hello!')` и `counter += 1` находятся внутри цикла, а `console.log('End of loop')` стоит за его пределами, поэтому выполнится один раз после завершения цикла.
+Здесь `console.log('Hello!')` и `counter = counter + 1` находятся внутри цикла, а `console.log('End of loop')` стоит за его пределами, поэтому выполнится один раз после завершения цикла.
 
 ## Цикл внутри функции
 
@@ -72,7 +72,7 @@ const printNumbers = (n) => {
   let i = 1;
   while (i <= n) {
     console.log(i);
-    i += 1;
+    i = i + 1;
   }
   console.log('Finished!');
 };

--- a/modules/50-loops/15-conditions-inside-loops/ru/README.md
+++ b/modules/50-loops/15-conditions-inside-loops/ru/README.md
@@ -8,7 +8,7 @@ while (number <= 10) {
   if (number % 2 === 0) {
     console.log(number);
   }
-  number += 1;
+  number = number + 1;
 }
 
 // => 2
@@ -51,10 +51,10 @@ const countChars = (str, char) => {
   while (i < str.length) {
     if (str[i] === char) {
       // Считаем только подходящие символы
-      count += 1;
+      count = count + 1;
     }
     // Счётчик увеличивается в любом случае
-    i += 1;
+    i = i + 1;
   }
 
   return count;

--- a/modules/50-loops/20-aggregation-numbers/index.js
+++ b/modules/50-loops/20-aggregation-numbers/index.js
@@ -1,16 +1,17 @@
+/* eslint operator-assignment: 0 */
 // BEGIN
 const calculateElectricityBill = (kwh) => {
   let total = 0;
   let current = 1;
   while (current <= kwh) {
     if (current <= 100) {
-      total += 5;
+      total = total + 5;
     } else if (current <= 200) {
-      total += 7;
+      total = total + 7;
     } else {
-      total += 10;
+      total = total + 10;
     }
-    current += 1;
+    current = current + 1;
   }
 
   return total;

--- a/modules/50-loops/23-aggregation-strings/index.js
+++ b/modules/50-loops/23-aggregation-strings/index.js
@@ -1,3 +1,4 @@
+/* eslint operator-assignment: 0 */
 // BEGIN
 const sanitizePhoneNumber = (phone) => {
   let result = '';
@@ -5,9 +6,9 @@ const sanitizePhoneNumber = (phone) => {
   while (i < phone.length) {
     const char = phone[i];
     if (!' ()-'.includes(char)) {
-      result += char;
+      result = result + char;
     }
-    i += 1;
+    i = i + 1;
   }
 
   return result;

--- a/modules/50-loops/25-iteration-over-string/index.js
+++ b/modules/50-loops/25-iteration-over-string/index.js
@@ -1,3 +1,4 @@
+/* eslint operator-assignment: 0 */
 // BEGIN
 const maskCardNumber = (cardNumber) => {
   let result = '';
@@ -5,11 +6,12 @@ const maskCardNumber = (cardNumber) => {
   const visiblePartStart = cardNumber.length - 4;
   while (i < cardNumber.length) {
     if (i < visiblePartStart) {
-      result += '*';
+      // biome-ignore lint/style/useTemplate: учебный пример до урока 30-syntax-sugar
+      result = result + '*';
     } else {
-      result += cardNumber[i];
+      result = result + cardNumber[i];
     }
-    i += 1;
+    i = i + 1;
   }
 
   return result;

--- a/modules/50-loops/28-build-strings/description.es.yml
+++ b/modules/50-loops/28-build-strings/description.es.yml
@@ -20,7 +20,7 @@ theory: |
     let result = '';
     while (i < str.length) {
       // Unir en orden inverso
-      result = `${str[i]}${result}`;
+      result = str[i] + result;
       // Lo mismo, pero con concatenación
       // result = str[i] + result;
       i = i + 1;

--- a/modules/50-loops/28-build-strings/en/README.md
+++ b/modules/50-loops/28-build-strings/en/README.md
@@ -16,7 +16,7 @@ const reverse = (str) => {
   let result = '';
   while (i < str.length) {
     // Connect it in reverse order
-    result = `${str[i]}${result}`;
+    result = str[i] + result;
     // Same through concatenation
     // result = str[i] + result;
     i = i + 1;

--- a/modules/50-loops/28-build-strings/es/README.md
+++ b/modules/50-loops/28-build-strings/es/README.md
@@ -16,7 +16,7 @@ const reverse = (str) => {
   let result = '';
   while (i < str.length) {
     // Unir en orden inverso
-    result = `${str[i]}${result}`;
+    result = str[i] + result;
     // Lo mismo, pero con concatenación
     // result = str[i] + result;
     i = i + 1;

--- a/modules/50-loops/28-build-strings/index.js
+++ b/modules/50-loops/28-build-strings/index.js
@@ -1,10 +1,11 @@
+/* eslint operator-assignment: 0 */
 // BEGIN
 const getEvenChars = (str) => {
   let i = 0;
   let result = '';
   while (i < str.length) {
     if (i % 2 !== 0) {
-      result = `${result}${str[i]}`;
+      result = result + str[i];
     }
     i = i + 1;
   }

--- a/modules/50-loops/28-build-strings/ru/README.md
+++ b/modules/50-loops/28-build-strings/ru/README.md
@@ -16,9 +16,7 @@ const reverse = (str) => {
   let result = '';
   while (i < str.length) {
     // Соединяем в обратном порядке
-    result = `${str[i]}${result}`;
-    // То же самое через конкатенацию
-    // result = str[i] + result;
+    result = str[i] + result;
     i = i + 1;
   }
 


### PR DESCRIPTION
Заменяет сокращённую форму `+=` (и шаблонные строки в index.js урока 28) на полную форму присваивания во всех шести уроках до `30-syntax-sugar`:

- `10-while/ru/README.md`
- `15-conditions-inside-loops/ru/README.md`
- `20-aggregation-numbers/index.js`
- `23-aggregation-strings/index.js`
- `25-iteration-over-string/index.js`
- `28-build-strings/index.js`, `28-build-strings/ru/README.md`

Восстанавливает драматургию курса: `+=` вводится как новый материал в уроке `30-syntax-sugar`, а не используется с первого примера.

T04 (docs/python-alignment-javascript/AUDIT.md, P1-4). Stacked поверх #836 — мержить после него.