### PR TITLE
fix: показывать вывод программы студента на панели «вывод»

### DIFF
--- a/modules/10-basics/10-hello-world/test.js
+++ b/modules/10-basics/10-hello-world/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/10-basics/40-instructions/test.js
+++ b/modules/10-basics/40-instructions/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('instructions', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/10-basics/40-instructions/test.js
+++ b/modules/10-basics/40-instructions/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/10-basics/45-testing/test.js
+++ b/modules/10-basics/45-testing/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/10-basics/45-testing/test.js
+++ b/modules/10-basics/45-testing/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('testing', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/10-basics/50-syntax-errors/test.js
+++ b/modules/10-basics/50-syntax-errors/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/10-basics/50-syntax-errors/test.js
+++ b/modules/10-basics/50-syntax-errors/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('syntax errors', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/20-arithmetics/20-basic/test.js
+++ b/modules/20-arithmetics/20-basic/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/20-arithmetics/20-basic/test.js
+++ b/modules/20-arithmetics/20-basic/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('basic', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/20-arithmetics/25-operator/test.js
+++ b/modules/20-arithmetics/25-operator/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('operator', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/20-arithmetics/25-operator/test.js
+++ b/modules/20-arithmetics/25-operator/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/20-arithmetics/27-commutativity/test.js
+++ b/modules/20-arithmetics/27-commutativity/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/20-arithmetics/27-commutativity/test.js
+++ b/modules/20-arithmetics/27-commutativity/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('commutativity', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/20-arithmetics/30-composition/test.js
+++ b/modules/20-arithmetics/30-composition/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('composition', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/20-arithmetics/30-composition/test.js
+++ b/modules/20-arithmetics/30-composition/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/20-arithmetics/40-priority/test.js
+++ b/modules/20-arithmetics/40-priority/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('priority', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/20-arithmetics/40-priority/test.js
+++ b/modules/20-arithmetics/40-priority/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/20-arithmetics/50-float/test.js
+++ b/modules/20-arithmetics/50-float/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/20-arithmetics/50-float/test.js
+++ b/modules/20-arithmetics/50-float/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('float', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/20-arithmetics/60-infinity/test.js
+++ b/modules/20-arithmetics/60-infinity/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/20-arithmetics/60-infinity/test.js
+++ b/modules/20-arithmetics/60-infinity/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('infinity', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/20-arithmetics/70-nan/test.js
+++ b/modules/20-arithmetics/70-nan/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/20-arithmetics/70-nan/test.js
+++ b/modules/20-arithmetics/70-nan/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('nan', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/20-arithmetics/80-linting/test.js
+++ b/modules/20-arithmetics/80-linting/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/20-arithmetics/80-linting/test.js
+++ b/modules/20-arithmetics/80-linting/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('linting', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/25-strings/10-quotes/test.js
+++ b/modules/25-strings/10-quotes/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('quotes', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/25-strings/10-quotes/test.js
+++ b/modules/25-strings/10-quotes/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/25-strings/15-escape-characters/test.js
+++ b/modules/25-strings/15-escape-characters/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('escape characters', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/25-strings/15-escape-characters/test.js
+++ b/modules/25-strings/15-escape-characters/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/25-strings/20-string-concatenation/test.js
+++ b/modules/25-strings/20-string-concatenation/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/25-strings/20-string-concatenation/test.js
+++ b/modules/25-strings/20-string-concatenation/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('string concatenation', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/25-strings/30-encoding/test.js
+++ b/modules/25-strings/30-encoding/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/25-strings/30-encoding/test.js
+++ b/modules/25-strings/30-encoding/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('encoding', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/30-variables/10-definition/test.js
+++ b/modules/30-variables/10-definition/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/30-variables/10-definition/test.js
+++ b/modules/30-variables/10-definition/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('definition', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/30-variables/11-change/test.js
+++ b/modules/30-variables/11-change/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('change', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/30-variables/11-change/test.js
+++ b/modules/30-variables/11-change/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/30-variables/13-variables-naming/test.js
+++ b/modules/30-variables/13-variables-naming/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('variables naming', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/30-variables/13-variables-naming/test.js
+++ b/modules/30-variables/13-variables-naming/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/30-variables/15-variables-expressions/test.js
+++ b/modules/30-variables/15-variables-expressions/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('variables expressions', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/30-variables/15-variables-expressions/test.js
+++ b/modules/30-variables/15-variables-expressions/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/30-variables/18-variable-concatenation/test.js
+++ b/modules/30-variables/18-variable-concatenation/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/30-variables/18-variable-concatenation/test.js
+++ b/modules/30-variables/18-variable-concatenation/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('variable concatenation', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/30-variables/19-naming-style/test.js
+++ b/modules/30-variables/19-naming-style/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('naming style', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/30-variables/19-naming-style/test.js
+++ b/modules/30-variables/19-naming-style/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/30-variables/20-magic-numbers/test.js
+++ b/modules/30-variables/20-magic-numbers/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/30-variables/20-magic-numbers/test.js
+++ b/modules/30-variables/20-magic-numbers/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('magic numbers', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/30-variables/23-constants/test.js
+++ b/modules/30-variables/23-constants/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/30-variables/23-constants/test.js
+++ b/modules/30-variables/23-constants/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('constants', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/31-advanced-strings/25-interpolation/test.js
+++ b/modules/31-advanced-strings/25-interpolation/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/31-advanced-strings/25-interpolation/test.js
+++ b/modules/31-advanced-strings/25-interpolation/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('interpolation', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/31-advanced-strings/30-symbols/test.js
+++ b/modules/31-advanced-strings/30-symbols/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/31-advanced-strings/30-symbols/test.js
+++ b/modules/31-advanced-strings/30-symbols/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('symbols', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/31-advanced-strings/70-slices/test.js
+++ b/modules/31-advanced-strings/70-slices/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('slices', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/31-advanced-strings/70-slices/test.js
+++ b/modules/31-advanced-strings/70-slices/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/31-advanced-strings/90-multiline-strings/test.js
+++ b/modules/31-advanced-strings/90-multiline-strings/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/31-advanced-strings/90-multiline-strings/test.js
+++ b/modules/31-advanced-strings/90-multiline-strings/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('multiline strings', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/33-data-types/10-primitive-data-types/test.js
+++ b/modules/33-data-types/10-primitive-data-types/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/33-data-types/10-primitive-data-types/test.js
+++ b/modules/33-data-types/10-primitive-data-types/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('primitive data types', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/33-data-types/45-undefined/test.js
+++ b/modules/33-data-types/45-undefined/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('undefined', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   // console.log must be called and must be passed an undefined argument

--- a/modules/33-data-types/50-data-types-weak-typing/test.js
+++ b/modules/33-data-types/50-data-types-weak-typing/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/33-data-types/50-data-types-weak-typing/test.js
+++ b/modules/33-data-types/50-data-types-weak-typing/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('data types weak typing', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/33-data-types/52-data-types-immutability/test.js
+++ b/modules/33-data-types/52-data-types-immutability/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/33-data-types/52-data-types-immutability/test.js
+++ b/modules/33-data-types/52-data-types-immutability/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('data types immutability', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/33-data-types/55-data-types-casting/test.js
+++ b/modules/33-data-types/55-data-types-casting/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/33-data-types/55-data-types-casting/test.js
+++ b/modules/33-data-types/55-data-types-casting/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('data types casting', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/35-calling-functions/100-call/test.js
+++ b/modules/35-calling-functions/100-call/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('call', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/35-calling-functions/100-call/test.js
+++ b/modules/35-calling-functions/100-call/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/35-calling-functions/135-calling-functions-default-params/test.js
+++ b/modules/35-calling-functions/135-calling-functions-default-params/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/35-calling-functions/135-calling-functions-default-params/test.js
+++ b/modules/35-calling-functions/135-calling-functions-default-params/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('calling functions default params', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/35-calling-functions/150-calling-functions-expression/test.js
+++ b/modules/35-calling-functions/150-calling-functions-expression/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/35-calling-functions/150-calling-functions-expression/test.js
+++ b/modules/35-calling-functions/150-calling-functions-expression/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('calling functions expression', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/35-calling-functions/180-variadic-parameters/test.js
+++ b/modules/35-calling-functions/180-variadic-parameters/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/35-calling-functions/180-variadic-parameters/test.js
+++ b/modules/35-calling-functions/180-variadic-parameters/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('variadic parameters', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/35-calling-functions/270-deterministic/test.js
+++ b/modules/35-calling-functions/270-deterministic/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('deterministic', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/35-calling-functions/270-deterministic/test.js
+++ b/modules/35-calling-functions/270-deterministic/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/38-objects/100-objects/test.js
+++ b/modules/38-objects/100-objects/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/38-objects/100-objects/test.js
+++ b/modules/38-objects/100-objects/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('objects', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/38-objects/200-methods-immutability/test.js
+++ b/modules/38-objects/200-methods-immutability/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/38-objects/200-methods-immutability/test.js
+++ b/modules/38-objects/200-methods-immutability/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('methods immutability', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/38-objects/500-method-chain/test.js
+++ b/modules/38-objects/500-method-chain/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/38-objects/500-method-chain/test.js
+++ b/modules/38-objects/500-method-chain/test.js
@@ -2,7 +2,7 @@
 
 import { expect, test, vi } from 'vitest';
 
-test('hello world', async () => {
+test('method chain', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   await import('./index.js');
 

--- a/modules/40-define-functions/100-define-function/test.js
+++ b/modules/40-define-functions/100-define-function/test.js
@@ -4,7 +4,7 @@ import { expect, test, vi } from 'vitest';
 import f from './index.js';
 
 test('hello world', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   f();
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/40-define-functions/100-define-function/test.js
+++ b/modules/40-define-functions/100-define-function/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 import f from './index.js';
 
-test('hello world', async () => {
+test('define function', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   f();
 

--- a/modules/40-define-functions/150-return/test.js
+++ b/modules/40-define-functions/150-return/test.js
@@ -3,7 +3,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('return', () => {
   expect(f('text', 3)).toBe('tex...');
   expect(f('hexlet learning', 6)).toBe('hexlet...');
 });

--- a/modules/40-define-functions/340-default-parameters/test.js
+++ b/modules/40-define-functions/340-default-parameters/test.js
@@ -3,7 +3,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('default parameters', () => {
   expect(f('1234123412341234')).toEqual('****1234');
   expect(f('1234123412344321')).toEqual('****4321');
   expect(f('1234123412344321', 2)).toEqual('**4321');

--- a/modules/40-define-functions/350-type-annotations/test.js
+++ b/modules/40-define-functions/350-type-annotations/test.js
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('type annotations', () => {
   const source = readFileSync(new URL('./index.js', import.meta.url), 'utf8');
   const paramAnnotations = source.match(/@param\s*\{/g) ?? [];
   expect(

--- a/modules/40-define-functions/450-define-functions-short-syntax/test.js
+++ b/modules/40-define-functions/450-define-functions-short-syntax/test.js
@@ -3,7 +3,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('define functions short syntax', () => {
   const expected1 = 'Daenerys';
   const actual1 = f('daenerys');
   expect(f(actual1)).toEqual(expected1);

--- a/modules/40-define-functions/460-modules/test.js
+++ b/modules/40-define-functions/460-modules/test.js
@@ -3,7 +3,7 @@
 import { expect, test } from 'vitest';
 import mirror from './index.js';
 
-test('mirror', () => {
+test('modules', () => {
   expect(mirror('hello')).toBe('OLLEH');
   expect(mirror('Hexlet')).toBe('TELXEH');
 });

--- a/modules/40-define-functions/470-packages/test.js
+++ b/modules/40-define-functions/470-packages/test.js
@@ -3,7 +3,7 @@
 import { expect, test } from 'vitest';
 import formatPrice from './index.js';
 
-test('formatPrice', () => {
+test('packages', () => {
   expect(formatPrice(12.3456)).toBe('12.35');
   expect(formatPrice(2.5)).toBe('2.50');
   expect(formatPrice(10)).toBe('10.00');

--- a/modules/45-logic/10-bool-type/test.js
+++ b/modules/45-logic/10-bool-type/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('bool type', () => {
   expect(f(23)).toBe(false);
   expect(f(70)).toBe(true);
   expect(f(60)).toBe(true);

--- a/modules/45-logic/17-bool-strings/test.js
+++ b/modules/45-logic/17-bool-strings/test.js
@@ -3,7 +3,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('bool strings', () => {
   expect(f('apple')).toBe(false);
   expect(f('banana')).toBe(true);
   expect(f('pineapple')).toBe(true);

--- a/modules/45-logic/20-logic-combine-expressions/test.js
+++ b/modules/45-logic/20-logic-combine-expressions/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('logic combine expressions', () => {
   expect(f('89602223423')).toBe(false);
   expect(f('+79602223423')).toBe(true);
 });

--- a/modules/45-logic/25-logical-operators/test.js
+++ b/modules/45-logic/25-logical-operators/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('logical operators', () => {
   expect(f(2016)).toBe(true);
   expect(f(2000)).toBe(true);
   expect(f(2017)).toBe(false);

--- a/modules/45-logic/28-logical-negation/test.js
+++ b/modules/45-logic/28-logical-negation/test.js
@@ -3,7 +3,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('logical negation', () => {
   expect(f('wow')).toBe(false);
   expect(f('hexlet')).toBe(true);
   expect(f('asdffdsa')).toBe(false);

--- a/modules/45-logic/70-logical-expressions/test.js
+++ b/modules/45-logic/70-logical-expressions/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('logical expressions', () => {
   const name = 'Hexlet';
   expect(f(name, 0)).toBe('');
   expect(f(name, 1)).toBe('H');

--- a/modules/48-conditionals/30-if/test.js
+++ b/modules/48-conditionals/30-if/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('if', () => {
   expect(f(100500)).toBe('Try again!');
   expect(f(42)).toBe('You win!');
 });

--- a/modules/48-conditionals/40-if-else/test.js
+++ b/modules/48-conditionals/40-if-else/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('if else', () => {
   expect(f('yandex.ru')).toBe('https://yandex.ru');
   expect(f('https://yandex.ru')).toBe('https://yandex.ru');
 });

--- a/modules/48-conditionals/50-else-if/test.js
+++ b/modules/48-conditionals/50-else-if/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('else if', () => {
   expect(f('green')).toBe('go');
   expect(f('yellow')).toBe('slow down');
   expect(f('red')).toBe('stop');

--- a/modules/48-conditionals/60-ternary-operator/test.js
+++ b/modules/48-conditionals/60-ternary-operator/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('ternary operator', () => {
   expect(f('flip')).toBe('flop');
   expect(f('flop')).toBe('flip');
   expect(f('hello')).toBe('flip');

--- a/modules/48-conditionals/65-switch/test.js
+++ b/modules/48-conditionals/65-switch/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('switch', () => {
   expect(f(0)).toBe('just a number');
   expect(f(666)).toBe('devil number');
   expect(f(42)).toBe('answer for everything');

--- a/modules/50-loops/10-while/test.js
+++ b/modules/50-loops/10-while/test.js
@@ -3,7 +3,7 @@
 import { expect, test, vi } from 'vitest';
 import f from './index.js';
 
-test('printNumbers', async () => {
+test('while', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   f(6);
 

--- a/modules/50-loops/10-while/test.js
+++ b/modules/50-loops/10-while/test.js
@@ -4,7 +4,7 @@ import { expect, test, vi } from 'vitest';
 import f from './index.js';
 
 test('printNumbers', async () => {
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, 'log');
   f(6);
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');

--- a/modules/50-loops/15-conditions-inside-loops/test.js
+++ b/modules/50-loops/15-conditions-inside-loops/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('conditions inside loops', () => {
   expect(f('axe', 'a')).toEqual(1);
   expect(f('', 'a')).toEqual(0);
   expect(f('OpPa', 'p')).toEqual(2);

--- a/modules/50-loops/20-aggregation-numbers/test.js
+++ b/modules/50-loops/20-aggregation-numbers/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('aggregation numbers', () => {
   expect(f(0)).toBe(0);
   expect(f(80)).toBe(400);
   expect(f(100)).toBe(500);

--- a/modules/50-loops/23-aggregation-strings/test.js
+++ b/modules/50-loops/23-aggregation-strings/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('aggregation strings', () => {
   expect(f('+7 (999) 123-45-67')).toBe('+79991234567');
   expect(f('8 800 555 35 35')).toBe('88005553535');
   expect(f('(123) 456-7890')).toBe('1234567890');

--- a/modules/50-loops/25-iteration-over-string/test.js
+++ b/modules/50-loops/25-iteration-over-string/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('iteration over string', () => {
   expect(f('1234567812345678')).toBe('************5678');
   expect(f('12345678')).toBe('****5678');
 });

--- a/modules/50-loops/30-syntactic-sugar/test.js
+++ b/modules/50-loops/30-syntactic-sugar/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('syntactic sugar', () => {
   const text = 'If I look back I am lost';
   expect(f(text, 'I')).toEqual('f  look back  am lost');
   expect(f('zz Zorro', 'z')).toEqual(' Zorro');

--- a/modules/50-loops/50-mutators/test.js
+++ b/modules/50-loops/50-mutators/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('mutators', () => {
   const text = 'I never look back';
   expect(f(text, 3)).toEqual('I NevEr LooK bAck');
   expect(f('hello', 2)).toEqual('hElLo');

--- a/modules/50-loops/55-return-from-loops/test.js
+++ b/modules/50-loops/55-return-from-loops/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('return from loops', () => {
   expect(f('support@example.com')).toBe(true);
   expect(f('wrong-email')).toBe(false);
   expect(f('@admin')).toBe(true);

--- a/modules/50-loops/70-for/test.js
+++ b/modules/50-loops/70-for/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('for', () => {
   expect(f(3)).toEqual('1 2 Fizz');
   expect(f(5)).toEqual('1 2 Fizz 4 Buzz');
   expect(f(15)).toEqual(

--- a/modules/50-loops/90-debug/test.js
+++ b/modules/50-loops/90-debug/test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import f from './index.js';
 
-test('test', () => {
+test('debug', () => {
   expect(f('aaabcccc')).toBe('a3bc4');
   expect(f('abcd')).toBe('abcd');
   expect(f('aabbaa')).toBe('a2b2a2');

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['**/*.test.js', '**/*.spec.js', '**/test.js'],
+    disableConsoleIntercept: true,
   },
 });


### PR DESCRIPTION
## Проблема

На панели **«вывод»** в JS-уроках студент не видел результат своего кода — только отчёт vitest. Аналог уже починенного в Python ([exercises-python#370](https://github.com/hexlet-basics/exercises-python/pull/370)).

Панель показывает дословный stdout от `make test` (→ vitest). Тесты «выводных» уроков глушили вывод строкой:

```js
vi.spyOn(console, 'log').mockImplementation(() => {})
```

Она записывает вызовы в `spy.mock.calls` (поэтому assert работает и задание засчитывается), но **подменяет** `console.log` пустышкой — реальной печати нет.

## Решение

Двухчастное:

1. **Сняли `.mockImplementation(() => {})`** в 44 `test.js`. `vi.spyOn(console, 'log')` без реализации и записывает вызовы (assert цел), и вызывает настоящий `console.log`.
2. **Добавили `disableConsoleIntercept: true`** в `vitest.config.js`. Иначе vitest перехватывает консоль и печатает с префиксом `stdout | test.js > <тест>`. С флагом вывод идёт в stdout **чисто** — прямой аналог pytest `--capture=no`.

Наглядно (урок `10-hello-world`):

| вариант | панель |
|---|---|
| было (мок) | *(только отчёт vitest)* |
| мок снят, без флага | `stdout \| test.js > hello world`<br>`Hello, World!` |
| мок снят + `disableConsoleIntercept` | `Hello, World!` |

## Предметные имена тест-кейсов (второй коммит)

Имя теста в каждом из 71 `test.js` приведено к теме урока — слаг каталога без числового префикса, дефисы → пробелы (`'hello world'`, `'string concatenation'`, `'if'`, `'while'`, `'define function'`…). Раньше было `'hello world'` у выводных и разрозненные `'test'`/`'mirror'`/`'printNumbers'`. Теперь на панели заголовок кейса отражает тему урока. Это только строка-описание — на assert не влияет.

## Область изменений

- `vitest.config.js` — одна опция.
- **44 `test.js`** — снятие мока (паттерн байт-в-байт единообразен), включая 2 урока с вызовом функции (`40-define-functions/100-define-function`, `50-loops/10-while`).
- **71 `test.js`** — предметное имя кейса.

Не менялись по существу: 27 невыводных `test.js` (проверяют возвращаемое значение) и `10-basics/20-comments` — только имя кейса.

## Проверка

- Чистый вывод на всех типах уроков (`Hello, World!`, многострочный, countdown); заголовок кейса — тема урока (`✓ test.js > if`, `✓ test.js > while`).
- `make compose-test` — вся сюита зелёная.
- `make compose-code-lint` (`tsc --build` + biome) — без ошибок (exit 0; warnings в `biome.json` — pre-existing, не относятся к правке).

🤖 Generated with [Claude Code](https://claude.com/claude-code)