### PR TITLE
Change expected console log output in test

### DIFF
--- a/modules/31-advanced-strings/30-symbols/test.js
+++ b/modules/31-advanced-strings/30-symbols/test.js
@@ -8,5 +8,5 @@ test('symbols', async () => {
 
   const firstArg = consoleLogSpy.mock.calls.join('\n');
 
-  expect(firstArg).toBe('grip');
+  expect(firstArg).toBe('s');
 });


### PR DESCRIPTION
the exercise says you need to return 's' but the test expects 'grip'