### PR TITLE
fix(31-symbols): sync en/es exercise text with ru ("grip")

### DIFF
--- a/modules/31-advanced-strings/30-symbols/description.es.yml
+++ b/modules/31-advanced-strings/30-symbols/description.es.yml
@@ -10,6 +10,6 @@ theory: |
   ```
 
 instructions: |
-  Imprime el último carácter de la constante dada.
+  En la cadena `text` se esconde una palabra secreta. Extrae los caracteres necesarios de la variable `text` por sus índices, únelos e imprime la palabra `grip`.
 
 tips: []

--- a/modules/31-advanced-strings/30-symbols/en/EXERCISE.md
+++ b/modules/31-advanced-strings/30-symbols/en/EXERCISE.md
@@ -1,1 +1,1 @@
-Given `name = 'Na\nharis'`, print the last character (`s`). Remember: `\n` is one character.
+A secret word is hidden in the `text` string. Extract the needed characters from the `text` variable by their indexes, join them, and print the word `grip`.

--- a/modules/31-advanced-strings/30-symbols/es/EXERCISE.md
+++ b/modules/31-advanced-strings/30-symbols/es/EXERCISE.md
@@ -1,1 +1,1 @@
-Dada `name = 'Na\nharis'`, imprime el último carácter (`s`).
+En la cadena `text` se esconde una palabra secreta. Extrae los caracteres necesarios de la variable `text` por sus índices, únelos e imprime la palabra `grip`.


### PR DESCRIPTION
## Что и зачем

В уроке `31-advanced-strings/30-symbols` тексты задания для локалей `en`/`es` остались от старой версии урока (`name = 'Na\nharis'` → вывести `s`) и рассинхронены с:

- `ru/EXERCISE.md` — задание «извлечь символы по индексам и вывести слово `grip`»;
- `index.js` — `console.log(\`${text[10]}${text[8]}${text[15]}${text[7]}\`)` для `text = 'Python programming'` → печатает `grip`;
- `test.js` — `expect(firstArg).toBe('grip')`.

Именно этот рассинхрон породил путаницу в #854: англоязычный студент читал старое задание про `s`, а тест ждёт `grip`. В #854 предложено поменять тест на `'s'`, но это ломает эталонное решение (`index.js` печатает `grip`). Правильное исправление — обновить устаревшие тексты заданий, что и делает этот PR.

## Изменения

- `en/EXERCISE.md` и `es/EXERCISE.md` приведены в соответствие с `ru` (задача про `grip`).
- `description.es.yml` (легаси-дубль es-локали на уровне урока) — поле `instructions` синхронизировано с `es/EXERCISE.md`, чтобы оба es-источника совпадали.
- Код решения и тест **не менялись** — они уже корректны.

## Замена для

Закрывает потребность #854 корректным способом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)