### PR TITLE
Точка с запятой в примерах с ошибками и каркас в variables-expressions

### DIFF
--- a/modules/10-basics/10-hello-world/ru/README.md
+++ b/modules/10-basics/10-hello-world/ru/README.md
@@ -36,10 +36,10 @@ console.log("it's JavaScript"); // апостроф внутри, поэтому
 
 ```javascript
 console.log("it's JavaScript"
-console.log(it's JavaScript")
-consol.log("it's JavaScript")
-console.log('it's JavaScript")
-consolelog("it's JavaScript")
+console.log(it's JavaScript");
+consol.log("it's JavaScript");
+console.log('it's JavaScript");
+consolelog("it's JavaScript");
 ```
 
 Даже небольшое отличие, например одна лишняя буква или другой знак, может привести к тому, что программа не будет работать. Это относится и к регистру, то есть к различию между большими и маленькими буквами. Если в обычном тексте `Привет` и `привет` выглядят одинаково, то для JavaScript это разные слова. JavaScript считает `console.log`, `Console.Log` и `CONSOLE.LOG` разными командами, и сработает только первый вариант.

--- a/modules/30-variables/15-variables-expressions/index.js
+++ b/modules/30-variables/15-variables-expressions/index.js
@@ -1,4 +1,6 @@
 const eurosCount = 100;
+
+// BEGIN
 const dollarsPerEuro = 1.25;
 const yuansPerDollar = 6.91;
 
@@ -7,3 +9,4 @@ const yuansCount = dollarsCount * yuansPerDollar;
 
 console.log(dollarsCount);
 console.log(yuansCount);
+// END


### PR DESCRIPTION
Две находки тьютора, проходившего курсы JS на Хекслете (эти уроки зеркалятся сюда).

**`10-basics/10-hello-world`** — урок просит найти ошибку в пяти строках, и в каждой она своя: кавычка, скобка или имя команды. Точки с запятой не было ни у одной строки, хотя во всех примерах выше она стоит: лишнее отличие читалось как ещё одна ошибка. Строка без закрывающей скобки остаётся без точки с запятой — ставить её некуда, пока скобка не закрыта.

**`30-variables/15-variables-expressions`** — условие говорит «дано количество евро: `eurosCount = 100`», а файл выдавался студенту целиком пустым, без маркеров. Теперь объявление константы лежит вне маркеров, решение внутри BEGIN/END — как в соседнем `35-calling-functions/150-calling-functions-expression`.

Тесты не менялись, проверка идёт по выводу.