### PR TITLE
fix(lessons): дописать про регистр в условие упражнения logical-negation

### DIFF
--- a/modules/45-logic/28-logical-negation/description.es.yml
+++ b/modules/45-logic/28-logical-negation/description.es.yml
@@ -91,6 +91,11 @@ instructions: |
   isPalindrome('hello');    // => false
   isNotPalindrome('level'); // => false
   isNotPalindrome('hello'); // => true
+
+  // Las cadenas pueden pasarse a las funciones en cualquier caso
+  // Por lo tanto, primero convierte la cadena a minúsculas con el método .toLowerCase()
+  isPalindrome('Wow');     // => true
+  isNotPalindrome('Wow');  // => false
   ```
 
   Usa los métodos `.split('')`, `.reverse()`, `.join('')` para invertir la cadena.

--- a/modules/45-logic/28-logical-negation/en/EXERCISE.md
+++ b/modules/45-logic/28-logical-negation/en/EXERCISE.md
@@ -8,6 +8,11 @@ isPalindrome("level"); // => true
 isPalindrome("hello"); // => false
 isNotPalindrome("level"); // => false
 isNotPalindrome("hello"); // => true
+
+// Strings can be passed to the functions in any case
+// So first convert the string to lowercase with the .toLowerCase() method
+isPalindrome("Wow"); // => true
+isNotPalindrome("Wow"); // => false
 ```
 
 Use the `.split('')`, `.reverse()`, `.join('')` methods to reverse the string.

--- a/modules/45-logic/28-logical-negation/es/EXERCISE.md
+++ b/modules/45-logic/28-logical-negation/es/EXERCISE.md
@@ -8,6 +8,11 @@ isPalindrome("level"); // => true
 isPalindrome("hello"); // => false
 isNotPalindrome("level"); // => false
 isNotPalindrome("hello"); // => true
+
+// Las cadenas pueden pasarse a las funciones en cualquier caso
+// Por lo tanto, primero convierte la cadena a minúsculas con el método .toLowerCase()
+isPalindrome("Wow"); // => true
+isNotPalindrome("Wow"); // => false
 ```
 
 Usa los métodos `.split('')`, `.reverse()`, `.join('')` para invertir la cadena.

--- a/modules/45-logic/28-logical-negation/ru/EXERCISE.md
+++ b/modules/45-logic/28-logical-negation/ru/EXERCISE.md
@@ -8,6 +8,11 @@ isPalindrome("level"); // => true
 isPalindrome("hello"); // => false
 isNotPalindrome("level"); // => false
 isNotPalindrome("hello"); // => true
+
+// Строки в функции могут быть переданы в любом регистре
+// Поэтому сначала приведите строку к нижнему регистру методом .toLowerCase()
+isPalindrome("Wow"); // => true
+isNotPalindrome("Wow"); // => false
 ```
 
 Используйте метод `.split('')`, `.reverse()`, `.join('')` для разворота строки.


### PR DESCRIPTION
## Что не так

Тест урока `45-logic/28-logical-negation` проверяет вызов с заглавной буквы:

```javascript
expect(f("Wow")).toBe(false);
```

Значит `isPalindrome("Wow")` обязан вернуть `true`, и эталонное решение это делает через `word.toLowerCase()`. Условие про регистр не говорило ничего, все его примеры были в нижнем регистре. Студент, реализовавший условие дословно (сравнение с учётом регистра), получал красный тест на верном по тексту решении, и причина в выводе теста не видна.

Нашёл студент Хекслета, разбор в тикете FEEDBACK-425.

## Что изменено

Дописано упоминание регистра с примером `Wow` из теста — в `ru/en/es EXERCISE.md` и в `description.es.yml` (ключ `instructions`). Тест и решение не менялись.

Формулировка по канону соседних стеков: в `php`, `python` и `java` регистр в этом задании описан во всех локалях, javascript оставался единственным стеком без этой строки.